### PR TITLE
Fix for #30, #33, and for unrecognized code

### DIFF
--- a/lib/pmd.js
+++ b/lib/pmd.js
@@ -81,7 +81,7 @@ pmd.processFile = function(file){
         code: '',
         issues: [],
         name: '',
-        type: jsonData.ctx.type,
+        type: '',
         types: [] // For package types (used by @type)
       },
       tagConstants = [], //temp array for tag with the name of @constant
@@ -89,8 +89,17 @@ pmd.processFile = function(file){
     ;
 
     if (jsonData.ignore) {
-      debug.log('Ignoring:', jsonData.ctx)
+      debug.log('Ignoring:', jsonData.ctx);
       return; // Skip this loop since ignoring
+    }
+
+    if (jsonData.ctx) {
+      entity.type = jsonData.ctx.type;
+    }
+    else {
+      // This may be too much output, do we have debug levels?
+      debug.log('Incorrectly parsed entry:', jsonData.code);
+      return; // Skip this loop since we dont know what this is
     }
 
     jsonData.tags.forEach(function(tag){


### PR DESCRIPTION
By moving the assignment of `type: jsonData.ctx.type` down below we can check that we have code/type that was correctly parsed by dox.
I think this addresses #33 and also fixes an issue I found where different comment blocks were incorrectly identified as documentation entities.
I think there are still improvements for dox.js we can do, but this fix allows more documentation to be generated without errors.
