### PR TITLE
Remove duplicates from HTML index table + Overloaded methods

### DIFF
--- a/lib/pmd.js
+++ b/lib/pmd.js
@@ -340,8 +340,11 @@ pmd.generateData = function(config){
   }); //config.folders.forEach
 
   // make the indexData available to all files
+  // remove duplicates from indexData
   objs.forEach(function(obj){
-    obj.fileData.files = indexData;
+    obj.fileData.files = indexData.filter(function(item, pos, ary) {
+                                            return !pos || item.name != ary[pos - 1].name;
+                                        });
   }); // objs.forEach
 
   return objs;
@@ -459,8 +462,12 @@ pmd.generateToc = function(config, objs){
 
     // Sort based on names
     // http://stackoverflow.com/questions/979256/sorting-an-array-of-javascript-objects
+    // Remove duplicates from array, as array was already sorted
+    // http://stackoverflow.com/questions/9229645/remove-duplicates-from-javascript-array
     indexData.files.sort(function(a, b) {
       return a.name.localeCompare(b.name);
+    }).filter(function(item, pos, ary) {
+        return !pos || item != ary[pos - 1];
     });
 
     templateContent = fs.readFileSync(path.resolve(config.toc.template),'utf8'),

--- a/lib/pmd.js
+++ b/lib/pmd.js
@@ -59,6 +59,27 @@ pmd.processFile = function(file){
     content = {}
   ;
 
+  var idList = {};
+  
+  function makeIdUnique(id) {
+    if (id in idList) {
+        // remove any existing suffix
+        var base = id.replace(/-\d+$/, "");
+        // generate a new suffix
+        var cnt = idList[base] || 1;
+        // while new suffix is in the list, keep making a different suffix
+        do {
+            id = base + "-" + cnt++;
+        } while (id in idList);
+        // save cnt for more efficient generation next time
+        idList[base] = cnt;
+    }
+    // put the final id in the list so it won't get used again in the future
+    idList[id] = true;
+    // return the newly generated unique id
+    return(id);
+}
+  
   debug.log('\nProcessing:', file.path);
 
   content.data = fs.readFileSync(file.path,'utf8'),
@@ -191,7 +212,8 @@ pmd.processFile = function(file){
 
     if (entity.code && (entity.type === pmd.DOCTYPES.FUNCTION || entity.type === pmd.DOCTYPES.PROCEDURE)){
 
-      entity.name = jsonData.ctx.name;
+      entity.name = makeIdUnique(jsonData.ctx.name);
+      entity.displayName = jsonData.ctx.name;
       // TODO mdsouza: cleanup?
       // entity.name = entity.code.match(/^\s*(procedure|function){1}\s+\w+/ig)[0];
       // entity.name = entity.name.replace(/^\s*(procedure|function){1}/ig, "").trim();

--- a/templates/package.html
+++ b/templates/package.html
@@ -235,7 +235,7 @@
             <section id="{{toUpperCase name}}" data-magellan-target="{{toUpperCase name}}">
                 <h3>
                     <span class="info label">{{initCap type}}</span>
-                    {{toUpperCase name}}
+                    {{toUpperCase displayName}}
                 </h3>
                 <h5 class="text-right"><small>Created {{#if author}}by {{author}}{{/if}} {{#if created}}on {{created}}{{/if}}</small></h5>
                 {{#ifCond author '||' created}}
@@ -312,7 +312,7 @@
                 <h3>Content</h3>
                 <ul class="vertical menu" data-magellan>
                     {{#each methods}} {{#unless isPrivate}} <!-- Don't show private methods-->
-                    <li><a href="#{{toUpperCase name}}">{{toUpperCase name}}</a></li>
+                    <li><a href="#{{toUpperCase name}}">{{toUpperCase displayName}}</a></li>
                     {{/unless}} {{/each}} {{! methods }}
                 </ul>
             </nav>


### PR DESCRIPTION
When creating documentation in HTML format, multiple links are generated in index table, if both - package specification and body are selected as parsed objects.