### PR TITLE
Added regex for TYPE OBJECT

### DIFF
--- a/lib/dox.js
+++ b/lib/dox.js
@@ -20,10 +20,10 @@ dox.contextPatternMatchers = [
 
   //Procedure/Function
   function (str) {
-    if (/^\s*(cursor|procedure|function)\s+([\w$]+)\s*/i.exec(str)) {
+    if (/^\s*((constructor|overriding member|member)?\s?(cursor|procedure|function))\s+([\w$]+)\s*/i.exec(str)) {
       return {
-        type: RegExp.$1.toLowerCase()
-        , name: RegExp.$2
+        type: RegExp.$3.toLowerCase()
+        , name: RegExp.$4
         // Split on ";" for pks files. This may occur when on JavaDoc fn then another fn without JavaDoc
         , header: str.split(/(\s+(as|is|begin)\s+|;)/gi)[0]
       };


### PR DESCRIPTION
This is to allow to add a comments into a types bodies as per packages e.g.

```
   /********************************************************************************
   *  Member function that prints to file all report instances and return filenames
   *
   *  @example
   *  t_reports.print_to_file(print_to_file);
   *
   *  @param p_filename t_varchar2_tab type OUT which contain list of filenames generated
   *
   *  @author Lukasz Wasylow
   *  @created 19/03/2019
   *
   **********************************************************************************/
   MEMBER PROCEDURE print_to_file(p_filename OUT t_varchar2_tab) IS
      v_filename t_varchar2_tab := t_varchar2_tab();
   BEGIN
      FOR instance IN 1 .. self.reporter_instances.COUNT LOOP
         v_filename.EXTEND;
         v_filename(v_filename.LAST) := print_to_file(self.reporter_instances(instance));
      END LOOP;
      p_filename := v_filename;
   END;
```
